### PR TITLE
fix topbar "MORE" button

### DIFF
--- a/src/components/topbar/topbar.module.css
+++ b/src/components/topbar/topbar.module.css
@@ -154,6 +154,7 @@
   background-color: var(--background-text);
   padding: 0 5px 0 15px;
   font-weight: bold;
+  margin-left: auto;
 }
 
 .moreLink:hover {


### PR DESCRIPTION
That small change should fix #156.
I tested it on both Linux and Android on Firefox and Chromium.
The last sub in the list and the more button are fully visible.