### PR TITLE
docs: fix wrong-org README links (bitsocialhq → bitsocialnet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build Status](https://img.shields.io/github/actions/workflow/status/bitsocialhq/seedit/test.yml?branch=master)](https://github.com/bitsocialhq/seedit/actions/workflows/test.yml)
-[![Release](https://img.shields.io/github/v/release/bitsocialhq/seedit)](https://github.com/bitsocialhq/seedit/releases/latest)
-[![License](https://img.shields.io/badge/license-GPL--2.0--only-red.svg)](https://github.com/bitsocialhq/seedit/blob/master/LICENSE)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/bitsocialnet/seedit/test.yml?branch=master)](https://github.com/bitsocialnet/seedit/actions/workflows/test.yml)
+[![Release](https://img.shields.io/github/v/release/bitsocialnet/seedit)](https://github.com/bitsocialnet/seedit/releases/latest)
+[![License](https://img.shields.io/badge/license-GPL--2.0--only-red.svg)](https://github.com/bitsocialnet/seedit/blob/master/LICENSE)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 <img src="https://github.com/plebeius-eth/assets/blob/main/seedit-logo.png" width="302" height="111">
@@ -14,8 +14,8 @@ Seedit is a serverless, adminless, decentralized and open-source (old)reddit alt
 - Seedit web version: https://seedit.app — or, using Brave/IPFS Companion: https://seedit.eth
 
 ### Downloads
-- Seedit desktop version (full p2p bitsocial node, seeds automatically): available for Mac/Windows/Linux, [download link in the release page](https://github.com/bitsocialhq/seedit/releases/latest)
-- Seedit mobile version: available for Android, [download link in the release page](https://github.com/bitsocialhq/seedit/releases/latest)
+- Seedit desktop version (full p2p bitsocial node, seeds automatically): available for Mac/Windows/Linux, [download link in the release page](https://github.com/bitsocialnet/seedit/releases/latest)
+- Seedit mobile version: available for Android, [download link in the release page](https://github.com/bitsocialnet/seedit/releases/latest)
 
 <br />
 
@@ -24,13 +24,13 @@ Seedit is a serverless, adminless, decentralized and open-source (old)reddit alt
 ## How to create a community
 To run a community, you can choose between two options:
 
-1. If you prefer to use a **GUI**, download the desktop version of the Seedit client, available for Windows, MacOS and Linux: [latest release](https://github.com/bitsocialhq/seedit/releases/latest). Create a community using using the familiar old.reddit-like UI, and modify its settings to your liking. The app runs an IPFS node, meaning you have to keep it running to have your board online.
-2. If you prefer to use a **command line interface**, install bitsocial-cli, available for Windows, MacOS and Linux: [latest release](https://github.com/bitsocialhq/bitsocial-cli/releases/latest). Follow the instructions in the readme of the repo. When running the daemon for the first time, it will output WebUI links you can use to manage your community with the ease of the GUI.
+1. If you prefer to use a **GUI**, download the desktop version of the Seedit client, available for Windows, MacOS and Linux: [latest release](https://github.com/bitsocialnet/seedit/releases/latest). Create a community using using the familiar old.reddit-like UI, and modify its settings to your liking. The app runs an IPFS node, meaning you have to keep it running to have your board online.
+2. If you prefer to use a **command line interface**, install bitsocial-cli, available for Windows, MacOS and Linux: [latest release](https://github.com/bitsocialnet/bitsocial-cli/releases/latest). Follow the instructions in the readme of the repo. When running the daemon for the first time, it will output WebUI links you can use to manage your community with the ease of the GUI.
 
-Peers can connect to your bitsocial community using any bitsocial client, such as Seedit or [5chan](https://github.com/bitsocialhq/5chan). They only need the community address, which is not stored in any central database, as bitsocial is a pure peer-to-peer protocol.
+Peers can connect to your bitsocial community using any bitsocial client, such as Seedit or [5chan](https://github.com/bitsocialnet/5chan). They only need the community address, which is not stored in any central database, as bitsocial is a pure peer-to-peer protocol.
 
 ### How to add a community to the default list (s/all)
-The default list of communities, used on s/all on Seedit, is bitsocial's [default-multisub.json list](https://github.com/bitsocialhq/lists/blob/master/default-multisub.json). You can open a pull request in that repo to add your community to the list.
+The default list of communities, used on s/all on Seedit, is bitsocial's [seedit-default-subscriptions.json list](https://github.com/bitsocialnet/lists/blob/master/seedit-default-subscriptions.json). You can open a pull request in that repo to add your community to the list.
 
 ## Contributor setup
 
@@ -55,4 +55,4 @@ The default web dev server runs at `https://seedit.localhost` via [Portless](htt
 
 ### Build:
 
-The linux/windows/mac/android build scripts are in https://github.com/bitsocialhq/seedit/blob/master/.github/workflows/release.yml
+The linux/windows/mac/android build scripts are in https://github.com/bitsocialnet/seedit/blob/master/.github/workflows/release.yml


### PR DESCRIPTION
## What

Corrects copy-paste org/repo errors in `README.md`. These links pointed at the old `bitsocialhq` org (since renamed to `bitsocialnet`), so they currently 404.

### Changes
- Build Status, Release, and License badges → `bitsocialnet/seedit`
- Desktop & mobile "download link in the release page" → `bitsocialnet/seedit`
- GUI "latest release" link → `bitsocialnet/seedit`
- bitsocial-cli "latest release" link → `bitsocialnet/bitsocial-cli`
- 5chan link → `bitsocialnet/5chan`
- Build-scripts (`release.yml`) link → `bitsocialnet/seedit`
- Default community list link → `bitsocialnet/lists`, and updated the filename to the current `seedit-default-subscriptions.json` (the old `default-multisub.json` no longer exists in that repo)

All target repos and paths were verified to exist under `bitsocialnet`.

**Scope:** link/badge corrections only — no license changes (those were handled separately).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and generated LLM context only; no runtime, auth, or dependency changes.
> 
> **Overview**
> Updates **README** GitHub URLs from the retired **`bitsocialhq`** org to **`bitsocialnet`** so badges, release downloads, related repos (**`bitsocial-cli`**, **`5chan`**), and the **`release.yml`** workflow link stop 404ing.
> 
> The **s/all** default-community doc now points at **`bitsocialnet/lists`** and **`seedit-default-subscriptions.json`** instead of the old **`default-multisub.json`** filename.
> 
> The embedded **README** section in **`public/llms-full.txt`** is updated to match so LLM context stays in sync with the readme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66df824d3f2bd206087c260c71c599b60843daa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->