### PR TITLE
feat: add responsive feed pagination defaults

### DIFF
--- a/public/translations/ar/default.json
+++ b/public/translations/ar/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "الاحتفاظ بكليهما",
   "keep_community": "الاحتفاظ بـ {{communityAddress}}",
   "directory_automatic_switch_notice": "تغيّر s/{{directoryCode}}، لذا حوّل Seedit اشتراكك من {{fromAddress}} إلى {{toAddress}}.",
-  "dismiss": "تجاهل"
+  "dismiss": "تجاهل",
+  "load_more": "تحميل المزيد",
+  "enable_infinite_feed": "تمكين الخلاصة اللانهائية",
+  "feeds": "الخلاصات"
 }

--- a/public/translations/bn/default.json
+++ b/public/translations/bn/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "দুটিই রাখুন",
   "keep_community": "{{communityAddress}} রাখুন",
   "directory_automatic_switch_notice": "s/{{directoryCode}} পরিবর্তিত হয়েছে, তাই Seedit আপনার সাবস্ক্রিপশন {{fromAddress}} থেকে {{toAddress}}-এ পরিবর্তন করেছে।",
-  "dismiss": "খারিজ করুন"
+  "dismiss": "খারিজ করুন",
+  "load_more": "আরও লোড করুন",
+  "enable_infinite_feed": "অসীম ফিড চালু করুন",
+  "feeds": "ফিডসমূহ"
 }

--- a/public/translations/cs/default.json
+++ b/public/translations/cs/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "ponechat obě",
   "keep_community": "ponechat {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} se změnilo, takže Seedit převedl vaše předplatné z {{fromAddress}} na {{toAddress}}.",
-  "dismiss": "Zavřít"
+  "dismiss": "Zavřít",
+  "load_more": "Načíst další",
+  "enable_infinite_feed": "Povolit nekonečný kanál",
+  "feeds": "kanály"
 }

--- a/public/translations/da/default.json
+++ b/public/translations/da/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "behold begge",
   "keep_community": "behold {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} er ændret, så Seedit skiftede dit abonnement fra {{fromAddress}} til {{toAddress}}.",
-  "dismiss": "Luk"
+  "dismiss": "Luk",
+  "load_more": "Indlæs flere",
+  "enable_infinite_feed": "Aktivér uendeligt feed",
+  "feeds": "feeds"
 }

--- a/public/translations/de/default.json
+++ b/public/translations/de/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "beide behalten",
   "keep_community": "{{communityAddress}} behalten",
   "directory_automatic_switch_notice": "s/{{directoryCode}} hat sich geändert, daher hat Seedit dein Abonnement von {{fromAddress}} zu {{toAddress}} gewechselt.",
-  "dismiss": "Ausblenden"
+  "dismiss": "Ausblenden",
+  "load_more": "Mehr laden",
+  "enable_infinite_feed": "Endlosen Feed aktivieren",
+  "feeds": "Feeds"
 }

--- a/public/translations/el/default.json
+++ b/public/translations/el/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "διατήρηση και των δύο",
   "keep_community": "διατήρηση του {{communityAddress}}",
   "directory_automatic_switch_notice": "Το s/{{directoryCode}} άλλαξε, οπότε το Seedit μετέφερε τη συνδρομή σας από το {{fromAddress}} στο {{toAddress}}.",
-  "dismiss": "Κλείσιμο"
+  "dismiss": "Κλείσιμο",
+  "load_more": "Φόρτωση περισσότερων",
+  "enable_infinite_feed": "Ενεργοποίηση ατελείωτης ροής",
+  "feeds": "ροές"
 }

--- a/public/translations/en/default.json
+++ b/public/translations/en/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "keep both",
   "keep_community": "keep {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} changed, so Seedit switched your subscription from {{fromAddress}} to {{toAddress}}.",
-  "dismiss": "dismiss"
+  "dismiss": "dismiss",
+  "load_more": "Load more",
+  "enable_infinite_feed": "Enable infinite feed",
+  "feeds": "feeds"
 }

--- a/public/translations/es/default.json
+++ b/public/translations/es/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "conservar ambas",
   "keep_community": "conservar {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} cambió, así que Seedit cambió tu suscripción de {{fromAddress}} a {{toAddress}}.",
-  "dismiss": "descartar"
+  "dismiss": "descartar",
+  "load_more": "Cargar más",
+  "enable_infinite_feed": "Activar feed infinito",
+  "feeds": "feeds"
 }

--- a/public/translations/fa/default.json
+++ b/public/translations/fa/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "هر دو را نگه دارید",
   "keep_community": "حفظ {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} تغییر کرد، بنابراین Seedit اشتراک شما را از {{fromAddress}} به {{toAddress}} منتقل کرد.",
-  "dismiss": "بستن"
+  "dismiss": "بستن",
+  "load_more": "بارگذاری بیشتر",
+  "enable_infinite_feed": "فعال‌سازی خوراک بی‌نهایت",
+  "feeds": "فیدها"
 }

--- a/public/translations/fi/default.json
+++ b/public/translations/fi/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "pidä molemmat",
   "keep_community": "säilytä {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} muuttui, joten Seedit vaihtoi tilauksesi yhteisöstä {{fromAddress}} yhteisöön {{toAddress}}.",
-  "dismiss": "Sulje"
+  "dismiss": "Sulje",
+  "load_more": "Lataa lisää",
+  "enable_infinite_feed": "Ota loputon syöte käyttöön",
+  "feeds": "syötteet"
 }

--- a/public/translations/fil/default.json
+++ b/public/translations/fil/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "panatilihin pareho",
   "keep_community": "panatilihin ang {{communityAddress}}",
   "directory_automatic_switch_notice": "Nagbago ang s/{{directoryCode}}, kaya inilipat ng Seedit ang subscription mo mula {{fromAddress}} papuntang {{toAddress}}.",
-  "dismiss": "Isara"
+  "dismiss": "Isara",
+  "load_more": "Mag-load pa",
+  "enable_infinite_feed": "I-enable ang walang katapusang feed",
+  "feeds": "mga feed"
 }

--- a/public/translations/fr/default.json
+++ b/public/translations/fr/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "garder les deux",
   "keep_community": "conserver {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} a changé, Seedit a donc remplacé votre abonnement à {{fromAddress}} par {{toAddress}}.",
-  "dismiss": "ignorer"
+  "dismiss": "ignorer",
+  "load_more": "Charger plus",
+  "enable_infinite_feed": "Activer le fil infini",
+  "feeds": "fils"
 }

--- a/public/translations/he/default.json
+++ b/public/translations/he/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "להשאיר את שניהם",
   "keep_community": "להשאיר את {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} השתנה, ולכן Seedit החליף את המינוי שלך מ־{{fromAddress}} ל־{{toAddress}}.",
-  "dismiss": "סגירה"
+  "dismiss": "סגירה",
+  "load_more": "טען עוד",
+  "enable_infinite_feed": "הפעלת פיד אינסופי",
+  "feeds": "פידים"
 }

--- a/public/translations/hi/default.json
+++ b/public/translations/hi/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "दोनों रखें",
   "keep_community": "{{communityAddress}} को रखें",
   "directory_automatic_switch_notice": "s/{{directoryCode}} बदल गया, इसलिए Seedit ने आपकी सदस्यता {{fromAddress}} से {{toAddress}} पर बदल दी।",
-  "dismiss": "बंद करें"
+  "dismiss": "बंद करें",
+  "load_more": "और लोड करें",
+  "enable_infinite_feed": "अनंत फ़ीड सक्षम करें",
+  "feeds": "फ़ीड"
 }

--- a/public/translations/hu/default.json
+++ b/public/translations/hu/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "mindkettő megtartása",
   "keep_community": "{{communityAddress}} megtartása",
   "directory_automatic_switch_notice": "Az s/{{directoryCode}} megváltozott, ezért a Seedit a feliratkozásodat {{fromAddress}} címről {{toAddress}} címre váltotta.",
-  "dismiss": "Bezárás"
+  "dismiss": "Bezárás",
+  "load_more": "Továbbiak betöltése",
+  "enable_infinite_feed": "Végtelen hírfolyam engedélyezése",
+  "feeds": "hírfolyamok"
 }

--- a/public/translations/id/default.json
+++ b/public/translations/id/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "simpan keduanya",
   "keep_community": "pertahankan {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} berubah, jadi Seedit mengalihkan langganan Anda dari {{fromAddress}} ke {{toAddress}}.",
-  "dismiss": "Tutup"
+  "dismiss": "Tutup",
+  "load_more": "Muat lebih banyak",
+  "enable_infinite_feed": "Aktifkan feed tanpa batas",
+  "feeds": "feed"
 }

--- a/public/translations/it/default.json
+++ b/public/translations/it/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "mantieni entrambe",
   "keep_community": "mantieni {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} è cambiato, quindi Seedit ha spostato la tua iscrizione da {{fromAddress}} a {{toAddress}}.",
-  "dismiss": "ignora"
+  "dismiss": "ignora",
+  "load_more": "Carica altro",
+  "enable_infinite_feed": "Abilita il feed infinito",
+  "feeds": "feed"
 }

--- a/public/translations/ja/default.json
+++ b/public/translations/ja/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "両方を維持",
   "keep_community": "{{communityAddress}}を維持する",
   "directory_automatic_switch_notice": "s/{{directoryCode}} が変更されたため、Seedit がサブスクリプションを {{fromAddress}} から {{toAddress}} に切り替えました。",
-  "dismiss": "閉じる"
+  "dismiss": "閉じる",
+  "load_more": "さらに読み込む",
+  "enable_infinite_feed": "無限フィードを有効にする",
+  "feeds": "フィード"
 }

--- a/public/translations/ko/default.json
+++ b/public/translations/ko/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "둘 다 유지",
   "keep_community": "{{communityAddress}} 유지",
   "directory_automatic_switch_notice": "s/{{directoryCode}}의 추천이 변경되어 Seedit에서 구독 대상을 {{fromAddress}}에서 {{toAddress}}로 전환했습니다.",
-  "dismiss": "닫기"
+  "dismiss": "닫기",
+  "load_more": "더 불러오기",
+  "enable_infinite_feed": "무한 피드 활성화",
+  "feeds": "피드"
 }

--- a/public/translations/mr/default.json
+++ b/public/translations/mr/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "दोन्ही ठेवा",
   "keep_community": "{{communityAddress}} ठेवा",
   "directory_automatic_switch_notice": "s/{{directoryCode}} बदलले, त्यामुळे Seedit ने तुमचे सदस्यत्व {{fromAddress}} वरून {{toAddress}} वर बदलले.",
-  "dismiss": "बंद करा"
+  "dismiss": "बंद करा",
+  "load_more": "आणखी लोड करा",
+  "enable_infinite_feed": "अमर्याद फीड सुरू करा",
+  "feeds": "फीड"
 }

--- a/public/translations/nl/default.json
+++ b/public/translations/nl/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "beide behouden",
   "keep_community": "{{communityAddress}} behouden",
   "directory_automatic_switch_notice": "s/{{directoryCode}} is gewijzigd, dus Seedit heeft je abonnement van {{fromAddress}} naar {{toAddress}} overgezet.",
-  "dismiss": "Sluiten"
+  "dismiss": "Sluiten",
+  "load_more": "Meer laden",
+  "enable_infinite_feed": "Oneindige feed inschakelen",
+  "feeds": "feeds"
 }

--- a/public/translations/no/default.json
+++ b/public/translations/no/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "behold begge",
   "keep_community": "behold {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} ble endret, så Seedit byttet abonnementet ditt fra {{fromAddress}} til {{toAddress}}.",
-  "dismiss": "Lukk"
+  "dismiss": "Lukk",
+  "load_more": "Last inn mer",
+  "enable_infinite_feed": "Aktiver uendelig feed",
+  "feeds": "feeder"
 }

--- a/public/translations/pl/default.json
+++ b/public/translations/pl/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "zachowaj obie",
   "keep_community": "zachowaj {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} zmieniło się, więc Seedit zmienił Twoją subskrypcję z {{fromAddress}} na {{toAddress}}.",
-  "dismiss": "Zamknij"
+  "dismiss": "Zamknij",
+  "load_more": "Załaduj więcej",
+  "enable_infinite_feed": "Włącz nieskończony kanał",
+  "feeds": "kanały"
 }

--- a/public/translations/pt/default.json
+++ b/public/translations/pt/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "manter ambas",
   "keep_community": "manter {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} mudou, então o Seedit alterou sua assinatura de {{fromAddress}} para {{toAddress}}.",
-  "dismiss": "dispensar"
+  "dismiss": "dispensar",
+  "load_more": "Carregar mais",
+  "enable_infinite_feed": "Ativar feed infinito",
+  "feeds": "feeds"
 }

--- a/public/translations/ro/default.json
+++ b/public/translations/ro/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "păstrează-le pe ambele",
   "keep_community": "păstrează {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} s-a schimbat, așa că Seedit ți-a mutat abonamentul de la {{fromAddress}} la {{toAddress}}.",
-  "dismiss": "Închide"
+  "dismiss": "Închide",
+  "load_more": "Încarcă mai multe",
+  "enable_infinite_feed": "Activează fluxul infinit",
+  "feeds": "fluxuri"
 }

--- a/public/translations/ru/default.json
+++ b/public/translations/ru/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "оставить оба",
   "keep_community": "оставить {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} изменился, поэтому Seedit переключил вашу подписку с {{fromAddress}} на {{toAddress}}.",
-  "dismiss": "Закрыть"
+  "dismiss": "Закрыть",
+  "load_more": "Загрузить ещё",
+  "enable_infinite_feed": "Включить бесконечную ленту",
+  "feeds": "ленты"
 }

--- a/public/translations/sq/default.json
+++ b/public/translations/sq/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "mbaji të dyja",
   "keep_community": "mbaj {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} ndryshoi, ndaj Seedit e kaloi abonimin tënd nga {{fromAddress}} te {{toAddress}}.",
-  "dismiss": "Mbyll"
+  "dismiss": "Mbyll",
+  "load_more": "Ngarko më shumë",
+  "enable_infinite_feed": "Aktivizo feed-in e pafund",
+  "feeds": "prurjet"
 }

--- a/public/translations/sv/default.json
+++ b/public/translations/sv/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "behåll båda",
   "keep_community": "behåll {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} ändrades, så Seedit bytte din prenumeration från {{fromAddress}} till {{toAddress}}.",
-  "dismiss": "Stäng"
+  "dismiss": "Stäng",
+  "load_more": "Ladda fler",
+  "enable_infinite_feed": "Aktivera oändligt flöde",
+  "feeds": "flöden"
 }

--- a/public/translations/te/default.json
+++ b/public/translations/te/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "రెండింటినీ ఉంచు",
   "keep_community": "{{communityAddress}}ను అలాగే ఉంచండి",
   "directory_automatic_switch_notice": "s/{{directoryCode}} మారింది, కాబట్టి Seedit మీ సబ్‌స్క్రిప్షన్‌ను {{fromAddress}} నుండి {{toAddress}}కి మార్చింది.",
-  "dismiss": "మూసివేయి"
+  "dismiss": "మూసివేయి",
+  "load_more": "మరిన్ని లోడ్ చేయండి",
+  "enable_infinite_feed": "అనంత ఫీడ్‌ను ప్రారంభించండి",
+  "feeds": "ఫీడ్‌లు"
 }

--- a/public/translations/th/default.json
+++ b/public/translations/th/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "เก็บไว้ทั้งคู่",
   "keep_community": "เก็บ {{communityAddress}} ไว้",
   "directory_automatic_switch_notice": "s/{{directoryCode}} มีการเปลี่ยนแปลง ดังนั้น Seedit จึงเปลี่ยนการสมัครของคุณจาก {{fromAddress}} เป็น {{toAddress}}",
-  "dismiss": "ปิด"
+  "dismiss": "ปิด",
+  "load_more": "โหลดเพิ่มเติม",
+  "enable_infinite_feed": "เปิดใช้งานฟีดแบบไม่สิ้นสุด",
+  "feeds": "ฟีด"
 }

--- a/public/translations/tr/default.json
+++ b/public/translations/tr/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "ikisini de tut",
   "keep_community": "{{communityAddress}} topluluğunu koru",
   "directory_automatic_switch_notice": "s/{{directoryCode}} değişti, bu nedenle Seedit aboneliğinizi {{fromAddress}} adresinden {{toAddress}} adresine geçirdi.",
-  "dismiss": "Kapat"
+  "dismiss": "Kapat",
+  "load_more": "Daha fazla yükle",
+  "enable_infinite_feed": "Sonsuz akışı etkinleştir",
+  "feeds": "akışlar"
 }

--- a/public/translations/uk/default.json
+++ b/public/translations/uk/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "залишити обидві",
   "keep_community": "залишити {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} змінився, тому Seedit перемкнув вашу підписку з {{fromAddress}} на {{toAddress}}.",
-  "dismiss": "Закрити"
+  "dismiss": "Закрити",
+  "load_more": "Завантажити ще",
+  "enable_infinite_feed": "Увімкнути нескінченну стрічку",
+  "feeds": "стрічки"
 }

--- a/public/translations/ur/default.json
+++ b/public/translations/ur/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "دونوں رکھیں",
   "keep_community": "{{communityAddress}} برقرار رکھیں",
   "directory_automatic_switch_notice": "s/{{directoryCode}} تبدیل ہو گیا، اس لیے Seedit نے آپ کی سبسکرپشن {{fromAddress}} سے {{toAddress}} پر منتقل کر دی۔",
-  "dismiss": "بند کریں"
+  "dismiss": "بند کریں",
+  "load_more": "مزید لوڈ کریں",
+  "enable_infinite_feed": "لامحدود فیڈ فعال کریں",
+  "feeds": "فیڈز"
 }

--- a/public/translations/vi/default.json
+++ b/public/translations/vi/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "giữ cả hai",
   "keep_community": "giữ {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} đã thay đổi, vì vậy Seedit đã chuyển đăng ký của bạn từ {{fromAddress}} sang {{toAddress}}.",
-  "dismiss": "Đóng"
+  "dismiss": "Đóng",
+  "load_more": "Tải thêm",
+  "enable_infinite_feed": "Bật bảng tin vô hạn",
+  "feeds": "bảng tin"
 }

--- a/public/translations/zh/default.json
+++ b/public/translations/zh/default.json
@@ -401,5 +401,8 @@
   "keep_both_communities": "两者都保留",
   "keep_community": "保留 {{communityAddress}}",
   "directory_automatic_switch_notice": "s/{{directoryCode}} 已更改，因此 Seedit 已将你的订阅从 {{fromAddress}} 切换到 {{toAddress}}。",
-  "dismiss": "关闭"
+  "dismiss": "关闭",
+  "load_more": "加载更多",
+  "enable_infinite_feed": "启用无限信息流",
+  "feeds": "信息流"
 }

--- a/src/components/feed-footer/feed-footer-utils.test.ts
+++ b/src/components/feed-footer/feed-footer-utils.test.ts
@@ -53,4 +53,8 @@ describe('shouldShowFeedLoading', () => {
   it('hides the loading message once manual pagination can be used', () => {
     expect(shouldShowFeedLoading({ feedLength: 25, hasMore: true, infiniteFeedEnabled: false })).toBe(false);
   });
+
+  it.each([false, true])('hides the loading message when a feed is exhausted and infinite mode is %s', (infiniteFeedEnabled) => {
+    expect(shouldShowFeedLoading({ feedLength: 25, hasMore: false, infiniteFeedEnabled })).toBe(false);
+  });
 });

--- a/src/components/feed-footer/feed-footer-utils.test.ts
+++ b/src/components/feed-footer/feed-footer-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { shouldShowEmptyFeed } from './feed-footer-utils';
+import { shouldShowEmptyFeed, shouldShowFeedLoading } from './feed-footer-utils';
 
 describe('shouldShowEmptyFeed', () => {
   it.each([0, 1, 60, 1000])('shows the empty state after all %i requested communities load even when pagination has more', (requestedCommunityCount) => {
@@ -42,5 +42,15 @@ describe('shouldShowEmptyFeed', () => {
     expect(shouldShowEmptyFeed({ ...loadedFeed, feedLength: 0, isLoadingCommunityData: true })).toBe(false);
     expect(shouldShowEmptyFeed({ ...loadedFeed, feedLength: 0, isSearching: true })).toBe(false);
     expect(shouldShowEmptyFeed({ ...loadedFeed, feedLength: 0, searchQuery: 'query' })).toBe(false);
+  });
+});
+
+describe('shouldShowFeedLoading', () => {
+  it('keeps the loading message visible during the first manual page fetch', () => {
+    expect(shouldShowFeedLoading({ feedLength: 0, hasMore: true, infiniteFeedEnabled: false })).toBe(true);
+  });
+
+  it('hides the loading message once manual pagination can be used', () => {
+    expect(shouldShowFeedLoading({ feedLength: 25, hasMore: true, infiniteFeedEnabled: false })).toBe(false);
   });
 });

--- a/src/components/feed-footer/feed-footer-utils.ts
+++ b/src/components/feed-footer/feed-footer-utils.ts
@@ -33,4 +33,4 @@ interface ShouldShowFeedLoadingOptions {
 }
 
 export const shouldShowFeedLoading = ({ feedLength, hasMore, infiniteFeedEnabled }: ShouldShowFeedLoadingOptions): boolean =>
-  feedLength === 0 || infiniteFeedEnabled || !hasMore;
+  feedLength === 0 || (infiniteFeedEnabled && hasMore);

--- a/src/components/feed-footer/feed-footer-utils.ts
+++ b/src/components/feed-footer/feed-footer-utils.ts
@@ -25,3 +25,12 @@ export const shouldShowEmptyFeed = ({
 
   return haveAllRequestedCommunitiesLoaded && feedLength === 0 && !isLoadingCommunityData && !isSearching && !searchQuery;
 };
+
+interface ShouldShowFeedLoadingOptions {
+  feedLength: number;
+  hasMore: boolean;
+  infiniteFeedEnabled: boolean;
+}
+
+export const shouldShowFeedLoading = ({ feedLength, hasMore, infiniteFeedEnabled }: ShouldShowFeedLoadingOptions): boolean =>
+  feedLength === 0 || infiniteFeedEnabled || !hasMore;

--- a/src/components/feed-footer/feed-footer.module.css
+++ b/src/components/feed-footer/feed-footer.module.css
@@ -21,13 +21,17 @@
   padding-bottom: 15px;
 }
 
+.loadMoreContainer {
+  padding-bottom: 15px;
+}
+
 @media (max-width: 640px) {
-  .morePostsSuggestion {
+  .morePostsSuggestion, .loadMoreContainer {
     padding-bottom: 10px;
   }
 }
 
-.morePostsSuggestion a, .link {
+.morePostsSuggestion a, .link, .loadMore {
   color: var(--text-primary);
   text-decoration: none;
   padding: 1px 4px;
@@ -40,7 +44,7 @@
   color: var(--link-primary);
 }
 
-.morePostsSuggestion a:hover, .link:hover {
+.morePostsSuggestion a:hover, .link:hover, .loadMore:hover {
   border: var(--pagination-button-border-hover);
 }
 

--- a/src/components/feed-footer/feed-footer.tsx
+++ b/src/components/feed-footer/feed-footer.tsx
@@ -6,6 +6,8 @@ import { isAllView, isModView } from '../../lib/utils/view-utils';
 import { useCommunityIdentifiers } from '../../hooks/use-community-identifier';
 import { useFeedStateString } from '../../hooks/use-state-string';
 import EmptyFeedMessage from '../empty-feed-message/empty-feed-message';
+import { useInfiniteFeedEnabled } from '../../hooks/use-feed-pagination';
+import FeedPagination from './feed-pagination';
 import LoadingEllipsis from '../loading-ellipsis';
 import { shouldShowEmptyFeed } from './feed-footer-utils';
 import styles from './feed-footer.module.css';
@@ -26,6 +28,7 @@ interface FeedFooterProps {
   isSearching?: boolean;
   showNoResults?: boolean;
   onClearSearch?: () => void;
+  onLoadMore: () => void;
 }
 
 const FeedFooter = ({
@@ -41,6 +44,7 @@ const FeedFooter = ({
   isSearching,
   showNoResults,
   onClearSearch,
+  onLoadMore,
 }: FeedFooterProps) => {
   let footerContent;
   const { t } = useTranslation();
@@ -48,6 +52,7 @@ const FeedFooter = ({
   const location = useLocation();
   const isInModView = isModView(location.pathname);
   const isInAllView = isAllView(location.pathname);
+  const infiniteFeedEnabled = useInfiniteFeedEnabled();
 
   const feedCommunityIdentifiers = useCommunityIdentifiers(communityAddresses);
   const { communities } = useCommunities({ communities: feedCommunityIdentifiers });
@@ -181,13 +186,20 @@ const FeedFooter = ({
               </div>
             )
           ) : !searchQuery ? (
-            <LoadingEllipsis string={feedStateString || loadingStateString} />
+            infiniteFeedEnabled || !hasMore ? (
+              <LoadingEllipsis string={feedStateString || loadingStateString} />
+            ) : null
           ) : null}
         </div>
       </>
     );
   }
-  return <div className={styles.footer}>{footerContent}</div>;
+  return (
+    <div className={styles.footer}>
+      {footerContent}
+      <FeedPagination feedLength={feedLength} hasMore={hasMore} onLoadMore={onLoadMore} />
+    </div>
+  );
 };
 
 export default React.memo(FeedFooter);

--- a/src/components/feed-footer/feed-footer.tsx
+++ b/src/components/feed-footer/feed-footer.tsx
@@ -9,7 +9,7 @@ import EmptyFeedMessage from '../empty-feed-message/empty-feed-message';
 import { useInfiniteFeedEnabled } from '../../hooks/use-feed-pagination';
 import FeedPagination from './feed-pagination';
 import LoadingEllipsis from '../loading-ellipsis';
-import { shouldShowEmptyFeed } from './feed-footer-utils';
+import { shouldShowEmptyFeed, shouldShowFeedLoading } from './feed-footer-utils';
 import styles from './feed-footer.module.css';
 import React from 'react';
 
@@ -186,7 +186,7 @@ const FeedFooter = ({
               </div>
             )
           ) : !searchQuery ? (
-            infiniteFeedEnabled || !hasMore ? (
+            shouldShowFeedLoading({ feedLength, hasMore, infiniteFeedEnabled }) ? (
               <LoadingEllipsis string={feedStateString || loadingStateString} />
             ) : null
           ) : null}

--- a/src/components/feed-footer/feed-pagination.test.tsx
+++ b/src/components/feed-footer/feed-pagination.test.tsx
@@ -49,6 +49,40 @@ describe('FeedPagination', () => {
     expect(onLoadMore).toHaveBeenCalledOnce();
   });
 
+  it('shows loading feedback and prevents repeated loads until the next page resolves', async () => {
+    let resolveLoadMore: (() => void) | undefined;
+    const onLoadMore = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLoadMore = resolve;
+        }),
+    );
+
+    await act(async () => {
+      root.render(createElement(FeedPagination, { feedLength: 25, hasMore: true, onLoadMore }));
+    });
+
+    await act(async () => {
+      container.querySelector('button')?.click();
+    });
+
+    expect(container.querySelector('button')).toBeNull();
+    expect(container.textContent).toContain('looking_for_more_posts');
+    expect(onLoadMore).toHaveBeenCalledOnce();
+
+    await act(async () => resolveLoadMore?.());
+
+    expect(container.querySelector('button')?.textContent).toBe('load_more');
+  });
+
+  it('hides manual pagination until the first page exists', async () => {
+    await act(async () => {
+      root.render(createElement(FeedPagination, { feedLength: 0, hasMore: true, onLoadMore: vi.fn() }));
+    });
+
+    expect(container.querySelector('button')).toBeNull();
+  });
+
   it('hides manual pagination when infinite feed is enabled', async () => {
     paginationState.infiniteFeedEnabled = true;
 

--- a/src/components/feed-footer/feed-pagination.test.tsx
+++ b/src/components/feed-footer/feed-pagination.test.tsx
@@ -83,6 +83,14 @@ describe('FeedPagination', () => {
     expect(container.querySelector('button')).toBeNull();
   });
 
+  it('hides manual pagination when loading more is unavailable', async () => {
+    await act(async () => {
+      root.render(createElement(FeedPagination, { feedLength: 25, hasMore: true, canLoadMore: false, onLoadMore: vi.fn() }));
+    });
+
+    expect(container.querySelector('button')).toBeNull();
+  });
+
   it('hides manual pagination when infinite feed is enabled', async () => {
     paginationState.infiniteFeedEnabled = true;
 

--- a/src/components/feed-footer/feed-pagination.test.tsx
+++ b/src/components/feed-footer/feed-pagination.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import * as React from 'react';
+import { createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import FeedPagination from './feed-pagination';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+const act = (React as { act?: (callback: () => void | Promise<void>) => void | Promise<void> }).act as (callback: () => void | Promise<void>) => void | Promise<void>;
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const paginationState = vi.hoisted(() => ({ infiniteFeedEnabled: false }));
+
+vi.mock('../../hooks/use-feed-pagination', () => ({
+  useInfiniteFeedEnabled: () => paginationState.infiniteFeedEnabled,
+}));
+
+describe('FeedPagination', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    paginationState.infiniteFeedEnabled = false;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('shows a manual load-more button by default and invokes it', async () => {
+    const onLoadMore = vi.fn();
+
+    await act(async () => {
+      root.render(createElement(FeedPagination, { feedLength: 25, hasMore: true, onLoadMore }));
+    });
+
+    const button = container.querySelector('button');
+    expect(button?.textContent).toBe('load_more');
+
+    await act(async () => button?.click());
+    expect(onLoadMore).toHaveBeenCalledOnce();
+  });
+
+  it('hides manual pagination when infinite feed is enabled', async () => {
+    paginationState.infiniteFeedEnabled = true;
+
+    await act(async () => {
+      root.render(createElement(FeedPagination, { feedLength: 25, hasMore: true, onLoadMore: vi.fn() }));
+    });
+
+    expect(container.querySelector('button')).toBeNull();
+  });
+});

--- a/src/components/feed-footer/feed-pagination.tsx
+++ b/src/components/feed-footer/feed-pagination.tsx
@@ -1,0 +1,26 @@
+import { useTranslation } from 'react-i18next';
+import { useInfiniteFeedEnabled } from '../../hooks/use-feed-pagination';
+import styles from './feed-footer.module.css';
+
+interface FeedPaginationProps {
+  feedLength: number;
+  hasMore: boolean;
+  onLoadMore: () => void;
+}
+
+const FeedPagination = ({ feedLength, hasMore, onLoadMore }: FeedPaginationProps) => {
+  const { t } = useTranslation();
+  const infiniteFeedEnabled = useInfiniteFeedEnabled();
+
+  if (infiniteFeedEnabled || !hasMore || feedLength === 0) return null;
+
+  return (
+    <div className={styles.loadMoreContainer}>
+      <button type='button' className={styles.loadMore} onClick={onLoadMore}>
+        {t('load_more')}
+      </button>
+    </div>
+  );
+};
+
+export default FeedPagination;

--- a/src/components/feed-footer/feed-pagination.tsx
+++ b/src/components/feed-footer/feed-pagination.tsx
@@ -7,15 +7,16 @@ import styles from './feed-footer.module.css';
 interface FeedPaginationProps {
   feedLength: number;
   hasMore: boolean;
+  canLoadMore?: boolean;
   onLoadMore: () => void | Promise<void>;
 }
 
-const FeedPagination = ({ feedLength, hasMore, onLoadMore }: FeedPaginationProps) => {
+const FeedPagination = ({ feedLength, hasMore, canLoadMore = true, onLoadMore }: FeedPaginationProps) => {
   const { t } = useTranslation();
   const infiniteFeedEnabled = useInfiniteFeedEnabled();
   const [isLoading, setIsLoading] = useState(false);
 
-  if (infiniteFeedEnabled || !hasMore || feedLength === 0) return null;
+  if (!canLoadMore || infiniteFeedEnabled || !hasMore || feedLength === 0) return null;
 
   const handleLoadMore = () => {
     if (isLoading) return;

--- a/src/components/feed-footer/feed-pagination.tsx
+++ b/src/components/feed-footer/feed-pagination.tsx
@@ -1,22 +1,45 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useInfiniteFeedEnabled } from '../../hooks/use-feed-pagination';
+import LoadingEllipsis from '../loading-ellipsis';
 import styles from './feed-footer.module.css';
 
 interface FeedPaginationProps {
   feedLength: number;
   hasMore: boolean;
-  onLoadMore: () => void;
+  onLoadMore: () => void | Promise<void>;
 }
 
 const FeedPagination = ({ feedLength, hasMore, onLoadMore }: FeedPaginationProps) => {
   const { t } = useTranslation();
   const infiniteFeedEnabled = useInfiniteFeedEnabled();
+  const [isLoading, setIsLoading] = useState(false);
 
   if (infiniteFeedEnabled || !hasMore || feedLength === 0) return null;
 
+  const handleLoadMore = () => {
+    if (isLoading) return;
+
+    setIsLoading(true);
+    void Promise.resolve()
+      .then(onLoadMore)
+      .then(
+        () => setIsLoading(false),
+        () => setIsLoading(false),
+      );
+  };
+
+  if (isLoading) {
+    return (
+      <div className={styles.stateString}>
+        <LoadingEllipsis string={t('looking_for_more_posts')} />
+      </div>
+    );
+  }
+
   return (
     <div className={styles.loadMoreContainer}>
-      <button type='button' className={styles.loadMore} onClick={onLoadMore}>
+      <button type='button' className={styles.loadMore} onClick={handleLoadMore}>
         {t('load_more')}
       </button>
     </div>

--- a/src/hooks/use-feed-pagination.test.ts
+++ b/src/hooks/use-feed-pagination.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { getInfiniteFeedEnabled } from './use-feed-pagination';
+
+describe('getInfiniteFeedEnabled', () => {
+  it('defaults to infinite loading on mobile and manual pagination on desktop', () => {
+    expect(getInfiniteFeedEnabled(null, true)).toBe(true);
+    expect(getInfiniteFeedEnabled(null, false)).toBe(false);
+  });
+
+  it('uses an explicit preference on every viewport', () => {
+    expect(getInfiniteFeedEnabled(false, true)).toBe(false);
+    expect(getInfiniteFeedEnabled(true, false)).toBe(true);
+  });
+});

--- a/src/hooks/use-feed-pagination.ts
+++ b/src/hooks/use-feed-pagination.ts
@@ -1,0 +1,12 @@
+import useContentOptionsStore from '../stores/use-content-options-store';
+import useIsMobile from './use-is-mobile';
+
+export const FEED_POSTS_PER_PAGE = 25;
+
+export const getInfiniteFeedEnabled = (preference: boolean | null, isMobile: boolean) => preference ?? isMobile;
+
+export const useInfiniteFeedEnabled = () => {
+  const preference = useContentOptionsStore((state) => state.infiniteFeedEnabled);
+  const isMobile = useIsMobile();
+  return getInfiniteFeedEnabled(preference, isMobile);
+};

--- a/src/stores/use-content-options-store.test.ts
+++ b/src/stores/use-content-options-store.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createStorage = () => {
+  const values = new Map<string, string>();
+  return {
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => [...values.keys()][index] ?? null,
+    get length() {
+      return values.size;
+    },
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, value),
+  } satisfies Storage;
+};
+
+describe('useContentOptionsStore', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('localStorage', createStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('defaults infinite feed to the responsive policy and persists explicit changes', async () => {
+    const { default: useContentOptionsStore } = await import('./use-content-options-store');
+
+    expect(useContentOptionsStore.getState().infiniteFeedEnabled).toBeNull();
+
+    useContentOptionsStore.getState().setInfiniteFeedEnabled(true);
+
+    expect(useContentOptionsStore.getState().infiniteFeedEnabled).toBe(true);
+    expect(localStorage.getItem('content-options')).toContain('"infiniteFeedEnabled":true');
+  });
+});

--- a/src/stores/use-content-options-store.ts
+++ b/src/stores/use-content-options-store.ts
@@ -14,6 +14,8 @@ interface ContentOptionsState {
   setAutoplayVideosOnComments: (autoplay: boolean) => void;
   muteVideosOnComments: boolean;
   setMuteVideosOnComments: (mute: boolean) => void;
+  infiniteFeedEnabled: boolean | null;
+  setInfiniteFeedEnabled: (enabled: boolean) => void;
 }
 
 interface ContentOptionsStore extends ContentOptionsState {
@@ -37,6 +39,7 @@ const useContentOptionsStore = create<ContentOptionsStore>()(
       mediaPreviewOption: 'autoExpandAll',
       autoplayVideosOnComments: true,
       muteVideosOnComments: true,
+      infiniteFeedEnabled: null,
       setBlurNsfwThumbnails: (blur) => set({ blurNsfwThumbnails: blur }),
       setHideNsfwCommunities: (hide) => set({ hideNsfwCommunities: hide }),
       setHasAcceptedWarning: (value) => set({ hasAcceptedWarning: value }),
@@ -46,6 +49,7 @@ const useContentOptionsStore = create<ContentOptionsStore>()(
       setMediaPreviewOption: (option) => set({ mediaPreviewOption: option }),
       setAutoplayVideosOnComments: (autoplay) => set({ autoplayVideosOnComments: autoplay }),
       setMuteVideosOnComments: (mute) => set({ muteVideosOnComments: mute }),
+      setInfiniteFeedEnabled: (enabled) => set({ infiniteFeedEnabled: enabled }),
     }),
     {
       name: 'content-options',

--- a/src/views/all/all.tsx
+++ b/src/views/all/all.tsx
@@ -133,13 +133,14 @@ const All = () => {
   });
 
   // Combined loadMore function for better performance when sort type isn't 'top'
-  const combinedLoadMore = () => {
-    loadMore();
+  const combinedLoadMore = async () => {
+    const loadMorePromises = [loadMore()];
     if (sortType !== 'top') {
-      if (hasMoreWeekly) loadMoreWeekly();
-      if (hasMoreMonthly) loadMoreMonthly();
-      if (hasMoreYearly) loadMoreYearly();
+      if (hasMoreWeekly) loadMorePromises.push(loadMoreWeekly());
+      if (hasMoreMonthly) loadMorePromises.push(loadMoreMonthly());
+      if (hasMoreYearly) loadMorePromises.push(loadMoreYearly());
     }
+    await Promise.all(loadMorePromises);
   };
 
   const documentTitle = 'seedit: ' + t('all_communities');
@@ -164,7 +165,7 @@ const All = () => {
   const lastVirtuosoState = lastVirtuosoStates?.[sortType + currentTimeFilterName + 'all' + searchQuery];
 
   const footerProps = {
-    feedLength: feed?.length,
+    feedLength: feed?.length ?? 0,
     hasFeedLoaded: !!feed,
     hasMore,
     communityAddresses,

--- a/src/views/all/all.tsx
+++ b/src/views/all/all.tsx
@@ -7,6 +7,7 @@ import { commentMatchesPattern } from '../../lib/utils/pattern-utils';
 import useFeedFiltersStore from '../../stores/use-feed-filters-store';
 import { useDefaultSubscriptionAddresses } from '../../hooks/use-default-subscriptions';
 import useTimeFilter, { isValidTimeFilterName } from '../../hooks/use-time-filter';
+import { FEED_POSTS_PER_PAGE, useInfiniteFeedEnabled } from '../../hooks/use-feed-pagination';
 import FeedFooter from '../../components/feed-footer';
 import { getCommunityIdentifiers } from '../../hooks/use-community-identifier';
 import LoadingEllipsis from '../../components/loading-ellipsis';
@@ -48,12 +49,14 @@ const All = () => {
   const currentTimeFilterName = params.timeFilterName || timeFilterName || 'hot';
 
   const { isSearching } = useFeedFiltersStore();
+  const infiniteFeedEnabled = useInfiniteFeedEnabled();
   const [showNoResults, setShowNoResults] = useState(false);
   const [searchAttemptCompleted, setSearchAttemptCompleted] = useState(false);
 
   const feedOptions = useMemo(() => {
     const options: any = {
       newerThan: searchQuery ? 0 : timeFilterSeconds,
+      postsPerPage: FEED_POSTS_PER_PAGE,
       sortType,
       communities: getCommunityIdentifiers(communityAddresses),
     };
@@ -174,6 +177,7 @@ const All = () => {
     searchQuery: searchQuery,
     isSearching,
     showNoResults,
+    onLoadMore: combinedLoadMore,
   };
 
   const handleClearSearch = () => {
@@ -228,7 +232,7 @@ const All = () => {
               itemContent={(index, post) => <Post key={post?.cid} index={index} post={post} />}
               useWindowScroll={true}
               components={{ Footer: () => <FeedFooter {...footerProps} /> }}
-              endReached={combinedLoadMore}
+              endReached={infiniteFeedEnabled ? combinedLoadMore : undefined}
               ref={virtuosoRef}
               restoreStateFrom={lastVirtuosoState}
               initialScrollTop={lastVirtuosoState?.scrollTop}

--- a/src/views/community/community.tsx
+++ b/src/views/community/community.tsx
@@ -34,6 +34,7 @@ interface FooterProps {
   communityAddresses: string[];
   communityAddress: string;
   feedLength: number;
+  paginationFeedLength: number;
   isOnline: boolean;
   hasCommunityLoaded: boolean;
   started: boolean;
@@ -51,6 +52,7 @@ const Footer = ({
   communityAddresses,
   communityAddress,
   feedLength,
+  paginationFeedLength,
   isOnline,
   hasCommunityLoaded,
   started: _started,
@@ -192,7 +194,7 @@ const Footer = ({
     }
   } else if (feedLength === 0 && isOnline && hasCommunityLoaded && !feedStateString) {
     footerFirstLine = <EmptyFeedMessage />;
-  } else if (feedLength === 0 || !isOnline) {
+  } else if (paginationFeedLength === 0 || !isOnline) {
     footerFirstLine = loadingString;
   } else if (hasMore && infiniteFeedEnabled) {
     footerFirstLine = loadingString;
@@ -222,7 +224,7 @@ const Footer = ({
         </>
       )}
       {footerSecondLine}
-      <FeedPagination feedLength={feedLength} hasMore={hasMore} onLoadMore={onLoadMore} />
+      <FeedPagination feedLength={paginationFeedLength} hasMore={hasMore} onLoadMore={onLoadMore} />
     </div>
   );
 };
@@ -328,6 +330,7 @@ const CommunityView = () => {
     communityAddresses,
     communityAddress,
     feedLength: combinedFeed.length || 0,
+    paginationFeedLength: feed?.length ?? 0,
     isOnline,
     hasCommunityLoaded: Boolean(updatedAt),
     started,

--- a/src/views/community/community.tsx
+++ b/src/views/community/community.tsx
@@ -16,9 +16,11 @@ import useIsCommunityOffline from '../../hooks/use-is-community-offline';
 import useResolvedCommunityRoute from '../../hooks/use-resolved-community-route';
 import { getCommunityPath, isResolvableCommunityAddress } from '../../lib/utils/community-route-utils';
 import useTimeFilter, { isValidTimeFilterName } from '../../hooks/use-time-filter';
+import { FEED_POSTS_PER_PAGE, useInfiniteFeedEnabled } from '../../hooks/use-feed-pagination';
 import { getCommunityIdentifier, getCommunityIdentifiers } from '../../hooks/use-community-identifier';
 import ErrorDisplay from '../../components/error-display';
 import EmptyFeedMessage from '../../components/empty-feed-message/empty-feed-message';
+import FeedPagination from '../../components/feed-footer/feed-pagination';
 import LoadingEllipsis from '../../components/loading-ellipsis';
 import Over18Warning from '../../components/over-18-warning';
 import Post from '../../components/post';
@@ -42,6 +44,7 @@ interface FooterProps {
   searchQuery: string;
   isSearching: boolean;
   setSearchParams: ReturnType<typeof useSearchParams>[1];
+  onLoadMore: () => void;
 }
 
 const Footer = ({
@@ -58,12 +61,14 @@ const Footer = ({
   searchQuery,
   isSearching,
   setSearchParams,
+  onLoadMore,
 }: FooterProps) => {
   const { t } = useTranslation();
   let footerFirstLine;
   let footerSecondLine;
   const feedStateString = useFeedStateString(communityAddresses);
   const loadingStateString = feedStateString || t('loading');
+  const infiniteFeedEnabled = useInfiniteFeedEnabled();
 
   const [showNoResults, setShowNoResults] = useState(false);
   const [searchAttemptCompleted, setSearchAttemptCompleted] = useState(false);
@@ -189,7 +194,7 @@ const Footer = ({
     footerFirstLine = <EmptyFeedMessage />;
   } else if (feedLength === 0 || !isOnline) {
     footerFirstLine = loadingString;
-  } else if (hasMore) {
+  } else if (hasMore && infiniteFeedEnabled) {
     footerFirstLine = loadingString;
   }
 
@@ -217,6 +222,7 @@ const Footer = ({
         </>
       )}
       {footerSecondLine}
+      <FeedPagination feedLength={feedLength} hasMore={hasMore} onLoadMore={onLoadMore} />
     </div>
   );
 };
@@ -256,10 +262,12 @@ const CommunityView = () => {
   const timeFilterName = params.timeFilterName || 'all';
   const { timeFilterSeconds } = useTimeFilter();
   const { isSearching } = useFeedFiltersStore();
+  const infiniteFeedEnabled = useInfiniteFeedEnabled();
 
   const feedOptions = useMemo(() => {
     const options: any = {
       communities: getCommunityIdentifiers(communityAddresses),
+      postsPerPage: FEED_POSTS_PER_PAGE,
       sortType,
       newerThan: searchQuery ? 0 : timeFilterSeconds,
     };
@@ -330,6 +338,7 @@ const CommunityView = () => {
     searchQuery,
     isSearching,
     setSearchParams,
+    onLoadMore: loadMore,
   };
 
   // scrolling position state for virtuoso feed
@@ -401,7 +410,7 @@ const CommunityView = () => {
           itemContent={(index, post) => <Post key={post?.cid} index={index} post={post} />}
           useWindowScroll={true}
           components={{ Footer: () => <Footer {...footerProps} /> }}
-          endReached={loadMore}
+          endReached={infiniteFeedEnabled ? loadMore : undefined}
           ref={virtuosoRef}
           restoreStateFrom={lastVirtuosoState}
           initialScrollTop={lastVirtuosoState?.scrollTop}

--- a/src/views/community/community.tsx
+++ b/src/views/community/community.tsx
@@ -224,7 +224,7 @@ const Footer = ({
         </>
       )}
       {footerSecondLine}
-      <FeedPagination feedLength={paginationFeedLength} hasMore={hasMore} onLoadMore={onLoadMore} />
+      <FeedPagination feedLength={paginationFeedLength} hasMore={hasMore} canLoadMore={isOnline} onLoadMore={onLoadMore} />
     </div>
   );
 };

--- a/src/views/domain/domain.tsx
+++ b/src/views/domain/domain.tsx
@@ -155,7 +155,7 @@ const Domain = () => {
   const lastVirtuosoState = lastVirtuosoStates?.[sortType + currentTimeFilterName + 'domain'];
 
   const footerProps = {
-    feedLength: feed?.length,
+    feedLength: feed?.length ?? 0,
     hasFeedLoaded: !!feed,
     hasMore,
     communityAddresses,

--- a/src/views/domain/domain.tsx
+++ b/src/views/domain/domain.tsx
@@ -6,6 +6,7 @@ import { commentMatchesPattern } from '../../lib/utils/pattern-utils';
 import useFeedFiltersStore from '../../stores/use-feed-filters-store';
 import { useDefaultSubscriptionAddresses } from '../../hooks/use-default-subscriptions';
 import useTimeFilter, { isValidTimeFilterName } from '../../hooks/use-time-filter';
+import { FEED_POSTS_PER_PAGE, useInfiniteFeedEnabled } from '../../hooks/use-feed-pagination';
 import FeedFooter from '../../components/feed-footer';
 import { getCommunityIdentifiers } from '../../hooks/use-community-identifier';
 import LoadingEllipsis from '../../components/loading-ellipsis';
@@ -28,6 +29,7 @@ const Domain = () => {
   const currentTimeFilterName = params.timeFilterName || timeFilterName || 'all';
 
   const { isSearching } = useFeedFiltersStore();
+  const infiniteFeedEnabled = useInfiniteFeedEnabled();
   const [showNoResults, setShowNoResults] = useState(false);
   const [searchAttemptCompleted, setSearchAttemptCompleted] = useState(false);
 
@@ -67,11 +69,13 @@ const Domain = () => {
 
     const options: {
       newerThan: number;
+      postsPerPage: number;
       sortType: string;
       communities: ReturnType<typeof getCommunityIdentifiers>;
       filter: CommentsFilter;
     } = {
       newerThan: searchQuery ? 0 : (timeFilterSeconds ?? 0),
+      postsPerPage: FEED_POSTS_PER_PAGE,
       sortType,
       communities: getCommunityIdentifiers(communityAddresses),
       filter: { filter: filterFunc, key: filterKey },
@@ -165,6 +169,7 @@ const Domain = () => {
     isSearching,
     showNoResults,
     domain,
+    onLoadMore: loadMore,
   };
 
   const handleClearSearch = () => {
@@ -220,7 +225,7 @@ const Domain = () => {
             itemContent={(index, post) => <Post index={index} post={post} />}
             useWindowScroll={true}
             components={{ Footer: () => <FeedFooter {...footerProps} /> }}
-            endReached={loadMore}
+            endReached={infiniteFeedEnabled ? loadMore : undefined}
             ref={virtuosoRef}
             restoreStateFrom={lastVirtuosoState}
             initialScrollTop={lastVirtuosoState?.scrollTop}

--- a/src/views/home/home.tsx
+++ b/src/views/home/home.tsx
@@ -8,6 +8,7 @@ import useFeedFiltersStore from '../../stores/use-feed-filters-store';
 import { useAutoSubscribeStore } from '../../stores/use-auto-subscribe-store';
 import useTimeFilter, { isValidTimeFilterName } from '../../hooks/use-time-filter';
 import useRedirectToDefaultSort from '../../hooks/use-redirect-to-default-sort';
+import { FEED_POSTS_PER_PAGE, useInfiniteFeedEnabled } from '../../hooks/use-feed-pagination';
 import { getCommunityIdentifiers } from '../../hooks/use-community-identifier';
 import { useStarterCommunityList } from '../../hooks/use-default-subscriptions';
 import FeedFooter from '../../components/feed-footer';
@@ -65,6 +66,7 @@ const Home = () => {
   const currentTimeFilterName = params.timeFilterName || timeFilterName || 'hot';
 
   const { isSearching } = useFeedFiltersStore();
+  const infiniteFeedEnabled = useInfiniteFeedEnabled();
   const [showNoResults, setShowNoResults] = useState(false);
   const [searchAttemptCompleted, setSearchAttemptCompleted] = useState(false);
 
@@ -79,7 +81,7 @@ const Home = () => {
   const feedOptions = useMemo(() => {
     const options: any = {
       newerThan: searchQuery ? 0 : timeFilterSeconds,
-      postsPerPage: 10,
+      postsPerPage: FEED_POSTS_PER_PAGE,
       sortType,
       communities: getCommunityIdentifiers(communityAddresses),
     };
@@ -213,6 +215,7 @@ const Home = () => {
       isSearching,
       showNoResults,
       onClearSearch,
+      onLoadMore: combinedLoadMore,
     }),
     [
       feed,
@@ -228,6 +231,7 @@ const Home = () => {
       isSearching,
       showNoResults,
       onClearSearch,
+      combinedLoadMore,
     ],
   );
 
@@ -301,7 +305,7 @@ const Home = () => {
               components={{
                 Footer: () => <FeedFooter {...footerProps} />,
               }}
-              endReached={combinedLoadMore}
+              endReached={infiniteFeedEnabled ? combinedLoadMore : undefined}
               ref={virtuosoRef}
               restoreStateFrom={lastVirtuosoState}
               initialScrollTop={lastVirtuosoState?.scrollTop}

--- a/src/views/home/home.tsx
+++ b/src/views/home/home.tsx
@@ -157,13 +157,14 @@ const Home = () => {
     newerThan: 60 * 60 * 24 * 365,
   });
 
-  const combinedLoadMore = useCallback(() => {
-    loadMore();
+  const combinedLoadMore = useCallback(async () => {
+    const loadMorePromises = [loadMore()];
     if (shouldLoadAdditionalFeeds) {
-      if (hasMoreWeekly) loadMoreWeekly();
-      if (hasMoreMonthly) loadMoreMonthly();
-      if (hasMoreYearly) loadMoreYearly();
+      if (hasMoreWeekly) loadMorePromises.push(loadMoreWeekly());
+      if (hasMoreMonthly) loadMorePromises.push(loadMoreMonthly());
+      if (hasMoreYearly) loadMorePromises.push(loadMoreYearly());
     }
+    await Promise.all(loadMorePromises);
   }, [loadMore, shouldLoadAdditionalFeeds, hasMoreWeekly, loadMoreWeekly, hasMoreMonthly, loadMoreMonthly, hasMoreYearly, loadMoreYearly]);
 
   const virtuosoRef = useRef<VirtuosoHandle | null>(null);
@@ -201,7 +202,7 @@ const Home = () => {
 
   const footerProps = useMemo(
     () => ({
-      feedLength: feed?.length,
+      feedLength: feed?.length ?? 0,
       hasFeedLoaded: !!feed,
       hasMore,
       communityAddresses,

--- a/src/views/mod/mod.tsx
+++ b/src/views/mod/mod.tsx
@@ -97,13 +97,14 @@ const Mod = () => {
   });
 
   // Combined loadMore function for better performance when sort type isn't 'top'
-  const combinedLoadMore = () => {
-    loadMore();
+  const combinedLoadMore = async () => {
+    const loadMorePromises = [loadMore()];
     if (sortType !== 'top') {
-      if (hasMoreWeekly) loadMoreWeekly();
-      if (hasMoreMonthly) loadMoreMonthly();
-      if (hasMoreYearly) loadMoreYearly();
+      if (hasMoreWeekly) loadMorePromises.push(loadMoreWeekly());
+      if (hasMoreMonthly) loadMorePromises.push(loadMoreMonthly());
+      if (hasMoreYearly) loadMorePromises.push(loadMoreYearly());
     }
+    await Promise.all(loadMorePromises);
   };
 
   // Reset no results state when search query changes
@@ -154,7 +155,7 @@ const Mod = () => {
   const lastVirtuosoState = lastVirtuosoStates?.[sortType + currentTimeFilterName + 'mod' + searchQuery];
 
   const footerProps = {
-    feedLength: feed?.length,
+    feedLength: feed?.length ?? 0,
     hasFeedLoaded: !!feed,
     hasMore,
     communityAddresses,

--- a/src/views/mod/mod.tsx
+++ b/src/views/mod/mod.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { commentMatchesPattern } from '../../lib/utils/pattern-utils';
 import useFeedFiltersStore from '../../stores/use-feed-filters-store';
 import useTimeFilter, { isValidTimeFilterName } from '../../hooks/use-time-filter';
+import { FEED_POSTS_PER_PAGE, useInfiniteFeedEnabled } from '../../hooks/use-feed-pagination';
 import FeedFooter from '../../components/feed-footer';
 import { getCommunityIdentifiers } from '../../hooks/use-community-identifier';
 import LoadingEllipsis from '../../components/loading-ellipsis';
@@ -38,6 +39,7 @@ const Mod = () => {
   }, [params?.sortType, params.timeFilterName, navigate]);
 
   const { isSearching } = useFeedFiltersStore();
+  const infiniteFeedEnabled = useInfiniteFeedEnabled();
   const [showNoResults, setShowNoResults] = useState(false);
   const [searchAttemptCompleted, setSearchAttemptCompleted] = useState(false);
   const { t } = useTranslation();
@@ -45,6 +47,7 @@ const Mod = () => {
   const feedOptions = useMemo(() => {
     const options: any = {
       newerThan: searchQuery ? 0 : timeFilterSeconds,
+      postsPerPage: FEED_POSTS_PER_PAGE,
       sortType,
       communities: getCommunityIdentifiers(communityAddresses),
     };
@@ -164,6 +167,7 @@ const Mod = () => {
     searchQuery: searchQuery,
     isSearching,
     showNoResults,
+    onLoadMore: combinedLoadMore,
   };
 
   const handleClearSearch = () => {
@@ -228,7 +232,7 @@ const Mod = () => {
               itemContent={(index, post) => <Post key={post?.cid} index={index} post={post} />}
               useWindowScroll={true}
               components={{ Footer: () => <FeedFooter {...footerProps} /> }}
-              endReached={combinedLoadMore}
+              endReached={infiniteFeedEnabled ? combinedLoadMore : undefined}
               ref={virtuosoRef}
               restoreStateFrom={lastVirtuosoState}
               initialScrollTop={lastVirtuosoState?.scrollTop}

--- a/src/views/settings/content-options/content-options.tsx
+++ b/src/views/settings/content-options/content-options.tsx
@@ -4,6 +4,7 @@ import styles from './content-options.module.css';
 import useContentOptionsStore from '../../../stores/use-content-options-store';
 import { useDefaultSubscriptions } from '../../../hooks/use-default-subscriptions';
 import { handleNSFWSubscriptionPrompt } from '../../../lib/utils/nsfw-subscription-utils';
+import { useInfiniteFeedEnabled } from '../../../hooks/use-feed-pagination';
 
 const MediaOptions = () => {
   const { t } = useTranslation();
@@ -163,6 +164,21 @@ const CommunitiesOptions = () => {
   );
 };
 
+const FeedOptions = () => {
+  const { t } = useTranslation();
+  const infiniteFeedEnabled = useInfiniteFeedEnabled();
+  const setInfiniteFeedEnabled = useContentOptionsStore((state) => state.setInfiniteFeedEnabled);
+
+  return (
+    <div className={styles.contentOptions}>
+      <label>
+        <input type='checkbox' checked={infiniteFeedEnabled} onChange={(event) => setInfiniteFeedEnabled(event.target.checked)} />
+        {t('enable_infinite_feed')}
+      </label>
+    </div>
+  );
+};
+
 const ContentOptions = () => {
   const { t } = useTranslation();
 
@@ -178,6 +194,12 @@ const ContentOptions = () => {
         <span className={styles.categoryTitle}>{t('communities')}</span>
         <span className={styles.categorySettings}>
           <CommunitiesOptions />
+        </span>
+      </div>
+      <div className={styles.category}>
+        <span className={styles.categoryTitle}>{t('feeds')}</span>
+        <span className={styles.categorySettings}>
+          <FeedOptions />
         </span>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- default desktop feeds to 25-post manual pages with a Load more button
- keep infinite scrolling enabled by default on mobile and preserve Virtuoso virtualization in both modes
- add a persisted content option, translations, and targeted pagination tests

## Verification

- `yarn test` (174 tests)
- `yarn lint`
- `yarn type-check`
- `yarn knip`
- `yarn build`
- `yarn exec react-doctor . --verbose --scope changed -y`
- Chrome, Firefox, and WebKit at desktop and mobile widths
- throttled Chromium feed smoke test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pagination across all main feed views and Virtuoso scroll behavior; regressions could cause double loads or stuck loading states, though tests cover key paths.
> 
> **Overview**
> Adds **responsive feed pagination**: desktop defaults to **25-post pages** with a **Load more** button; mobile keeps **infinite scroll** via Virtuoso `endReached` unless the user overrides it.
> 
> A new **Feeds** section in content options persists an **Enable infinite feed** preference (`null` = device default). `useInfiniteFeedEnabled` resolves that policy; `FeedPagination` shows the button only when infinite mode is off, blocks duplicate loads while a page fetch is in flight, and footer loading text is gated by `shouldShowFeedLoading`.
> 
> Feed views (home, all, mod, domain, community) pass `FEED_POSTS_PER_PAGE`, wire `onLoadMore` (including `Promise.all` for combined weekly/monthly/yearly loads), and disable scroll-triggered loading when manual pagination is active. Locale files add `load_more`, `enable_infinite_feed`, and `feeds` strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a27f6780847f35eb7e2c1553a3e03e8df1597a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to enable infinite feed scrolling, with device-appropriate defaults.
  * Added “Load more” pagination when infinite scrolling is disabled.
  * Added loading indicators and improved pagination behavior across feed views.
  * Added localized labels for feed settings and pagination in supported languages.

* **Bug Fixes**
  * Prevented duplicate load requests while pagination is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->